### PR TITLE
検索窓を追加

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -31,11 +31,9 @@ if (process.env.BUILD_TYPE === 'prd' || process.env.BUILD_TYPE === 'local') {
     require.resolve('@cmfcmf/docusaurus-search-local'),
     {
       indexDocs: true,
-      indexDocSidebarParentCategories: 1,
       indexPages: true,
       indexBlog: false,
-      language: ['en', 'ja'],
-      lunr: {tokenizerSeparator: /[\s-]+/gu},
+      language: ['ja'],
     },
   ]);
 }

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,11 +4,14 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const organization = 'fintan-contents';
 const project = 'gai-dev-guide';
-const urlWithBase = `https://${organization}.github.io/${project}/`;
-const ogpImageUrl = `${urlWithBase}img/OGP.png`;
 
-const baseUrl = process.env.BUILD_USABLE_WITHOUT_SERVER === 'true' ? '' : `/${project}/`;
-const experimental_router = process.env.BUILD_USABLE_WITHOUT_SERVER === 'true' ? 'hash' : 'browser';
+const url = process.env.BUILD_TYPE === 'prd' ? 'https://${organization}.github.io' : 'http://localhost:3000';
+const baseUrl = process.env.BUILD_TYPE === 'prd' ? `/${project}/` : '';
+const urlWithBase = url + baseUrl
+const ogpImageUrl = `${urlWithBase}img/OGP.png`;
+const repositoryUrl = `https://github.com/${organization}/${project}`
+
+const experimental_router = process.env.BUILD_TYPE === 'usableWithoutServer' ? 'hash' : 'browser';
 
 const copyright = `
 <div class="no-content">
@@ -21,10 +24,26 @@ const copyright = `
   </div>
 </div>`;
 
+
+const plugins = [];
+if (process.env.BUILD_TYPE === 'prd' || process.env.BUILD_TYPE === 'local') {
+  plugins.push([
+    require.resolve('@cmfcmf/docusaurus-search-local'),
+    {
+      indexDocs: true,
+      indexDocSidebarParentCategories: 1,
+      indexPages: true,
+      indexBlog: false,
+      language: ['en', 'ja'],
+      lunr: {tokenizerSeparator: /[\s-]+/gu},
+    },
+  ]);
+}
+
 const config: Config = {
   title: 'Fintan » Development Guide with Generative AI',
   tagline: '',
-  url: `https://${organization}.github.io`,
+  url,
   baseUrl,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -38,7 +57,7 @@ const config: Config = {
     defaultLocale: 'ja',
     locales: ['ja'],
   },
-
+  plugins,
   presets: [
     [
       'classic',
@@ -117,7 +136,7 @@ ChatGPTやGitHub Copilotなどの導入方法、基本的な操作、効果的�
           label: 'プロンプト',
         },
         {
-          href: `https://github.com/${organization}/${project}`,
+          href: repositoryUrl,
           position: 'right',
           className: 'header-github-link',
           'aria-label': 'GitHub repository',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,7 @@
       "name": "website",
       "version": "0.0.0",
       "dependencies": {
+        "@cmfcmf/docusaurus-search-local": "^1.2.0",
         "@docusaurus/core": "3.5.2",
         "@docusaurus/preset-classic": "3.5.2",
         "@mdx-js/react": "^3.0.0",
@@ -46,6 +47,63 @@
         "@algolia/autocomplete-shared": "1.9.3"
       }
     },
+    "node_modules/@algolia/autocomplete-js": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-js/-/autocomplete-js-1.17.7.tgz",
+      "integrity": "sha512-4rCCg2B5x6GYzLfDZ3QipWydznbaMjoIwNSEbjpJ9cd/0+4nDpRWuBPxgOSsGmE4BFEor2iwQw4uCY6RrBdpjA==",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7",
+        "htm": "^3.1.1",
+        "preact": "^10.13.2"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.5.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
@@ -77,6 +135,11 @@
         "@algolia/client-search": ">= 4.9.1 < 6",
         "algoliasearch": ">= 4.9.1 < 6"
       }
+    },
+    "node_modules/@algolia/autocomplete-theme-classic": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-theme-classic/-/autocomplete-theme-classic-1.17.7.tgz",
+      "integrity": "sha512-8sxnzRCPxyKZJxbG7EUpV/3AssQOjn+Zq/nvzks+BwbkAcpiLRBsXjvlIIsV4l36bZ+/Ri++ttAflGDPrRfn1A=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
       "version": "4.24.0",
@@ -2202,6 +2265,58 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cmfcmf/docusaurus-search-local": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@cmfcmf/docusaurus-search-local/-/docusaurus-search-local-1.2.0.tgz",
+      "integrity": "sha512-Tc0GhRBsfZAiB+f6BoPB8YCQap6JzzcDyJ0dLSCSzWQ6wdWvDlTBrHc1YqR8q8AZ+STRszL5eZpZFi5dbTCdYg==",
+      "dependencies": {
+        "@algolia/autocomplete-js": "^1.8.2",
+        "@algolia/autocomplete-theme-classic": "^1.8.2",
+        "@algolia/client-search": "^4.12.0",
+        "algoliasearch": "^4.12.0",
+        "cheerio": "^1.0.0-rc.9",
+        "clsx": "^1.1.1",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1",
+        "tslib": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^2.0.0",
+        "nodejieba": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "nodejieba": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cmfcmf/docusaurus-search-local/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@cmfcmf/docusaurus-search-local/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@cmfcmf/docusaurus-search-local/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@colors/colors": {
@@ -8887,6 +9002,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+    },
     "node_modules/html-entities": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
@@ -10301,6 +10421,16 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lunr-languages": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.14.0.tgz",
+      "integrity": "sha512-hWUAb2KqM3L7J5bcrngszzISY4BxrXn/Xhbb9TTCJYEGqlR1nG67/M14sp09+PTIRklobrn57IAxcdcO/ZFyNA=="
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",
@@ -14454,6 +14584,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.25.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.0.tgz",
+      "integrity": "sha512-6bYnzlLxXV3OSpUxLdaxBmE7PMOu0aR3pG6lryK/0jmvcDFPlcXGQAt5DpK3RITWiDrfYZRI0druyaK/S9kYLg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {

--- a/website/package.json
+++ b/website/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
-    "build:usableWithoutServer": "cross-env BUILD_USABLE_WITHOUT_SERVER=true docusaurus build",
+    "build": "cross-env BUILD_TYPE=prd docusaurus build",
+    "build:local": "cross-env BUILD_TYPE=local docusaurus build",
+    "build:usableWithoutServer": "cross-env BUILD_TYPE=usableWithoutServer docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -18,6 +19,7 @@
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"**/*.mdx\" \"#node_modules\" \"#build\""
   },
   "dependencies": {
+    "@cmfcmf/docusaurus-search-local": "^1.2.0",
     "@docusaurus/core": "3.5.2",
     "@docusaurus/preset-classic": "3.5.2",
     "@mdx-js/react": "^3.0.0",
@@ -42,6 +44,11 @@
     "textlint-rule-preset-jtf-style": "^2.3.14",
     "textlint-rule-prh": "^6.0.0",
     "typescript": "~5.5.2"
+  },
+  "overrides": {
+    "@cmfcmf/docusaurus-search-local": {
+      "@docusaurus/core": "3.5.2"
+    }
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## 使い勝手は以下で試せます

以下コマンド実施して、localhost:3000にアクセスしてください。ヘッダ右上に検索窓が追加されているはずです。

```bash
git checkout feat/search
cd website
npm ci
npm run build:local
npm run serve
```

## やったこと
- 本題
  - 外部ツールを使用せずに実装できるDocusaurus用の検索窓([docusaurus-search-local](https://github.com/easyops-cn/docusaurus-search-local))を追加。
    - docusaurus-search-localはHTMLファイル検索を前提としている（[参考：GitHub issue](https://github.com/facebook/docusaurus/issues/3825#issuecomment-2219789003)）ので、hashによるビルドでは使えない。
      - そのためnpm scripts `build:usableWithoutServer`では、検索窓は入れないようにしている
- 本題以外
  - ローカルでサーバー立ち上げる用のビルド設定を追加
  - ビルドの種類を示す環境変数`BUILD_TYPE`（'prd' | 'local' | 'usableWithoutServer'）を追加