### PR TITLE
ホームパス生成ロジック修正

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -5,7 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 const organization = 'fintan-contents';
 const project = 'gai-dev-guide';
 
-const url = process.env.BUILD_TYPE === 'prd' ? 'https://${organization}.github.io' : 'http://localhost:3000';
+const url = process.env.BUILD_TYPE === 'prd' ? `https://${organization}.github.io` : 'http://localhost:3000';
 const baseUrl = process.env.BUILD_TYPE === 'prd' ? `/${project}/` : '';
 const urlWithBase = url + baseUrl
 const ogpImageUrl = `${urlWithBase}img/OGP.png`;


### PR DESCRIPTION
## 修正概要

docusaurus.config.ts にて、URL生成ロジックが間違っていたので修正。
- 修正前：
  - 挙動：サイトのヘッダー左部分のロゴをクリックすると、`https://${organization}.github.io/gai-dev-guide/`に遷移
  - 実装：文字列置換すべき箇所で シングルクォートで囲んだ文字列を使用
- 修正後：
  - 挙動：ローカルで動作以下確認実施
    - ローカルPCで`npm run build`して生成されたindex.htmlのtwitter向けOGPなどのURLが修正されていることを確認
    - ローカルPCで`npm run build`して`npm run serve`してブラウザに表示された`Fintan » 生成AI活用ガイド`リンクをクリックして、https://fintan-contents.github.io/gai-dev-guide/ に遷移することを確認
  - 実装：文字列置換すべき箇所でバッククォートで囲んだ文字列を使用
 