### PR TITLE
plausibleでアクセス数を収集する設定を追加／ISSUE #19対応

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -10,12 +10,12 @@
 
 ## アクセス数集計
 
-plausibleを用いてアクセス数を集計する。
+plausibleを用いてアクセス数を集計します。
 
 アクセス数は以下から閲覧可能  
-https://plausible.io/gai-dev-guide.fintan-contents.github.io/installation
+[https://plausible.io/gai-dev-guide.fintan-contents.github.io/installation](https://plausible.io/gai-dev-guide.fintan-contents.github.io/installation)
 
-`website\docusaurus.config.ts`の下記scriptsを追加することにより、plausibleにアクセス数が集計される仕組みになっている。
+`website\docusaurus.config.ts`の下記scriptsを追加することにより、plausibleにアクセス数が集計される仕組みになっています。
 
 ```js
   ・
@@ -39,4 +39,4 @@ https://plausible.io/gai-dev-guide.fintan-contents.github.io/installation
   ・
 ```
 
-なお、テストなどでローカルで起動したサーバーにアクセスした際は、集計対象にならない。
+なお、ローカルで起動したサーバにアクセスした際は、集計対象になりません。

--- a/website/README.md
+++ b/website/README.md
@@ -7,3 +7,36 @@
 ## ライセンス
 
 ドキュメントは、<a rel="license" href="https://fintan.jp/?page_id=201" target="_blank">Fintanコンテンツ使用許諾条項</a>の下に提供されています。
+
+## アクセス数集計
+
+plausibleを用いてアクセス数を集計する。
+
+アクセス数は以下から閲覧可能  
+https://plausible.io/gai-dev-guide.fintan-contents.github.io/installation
+
+`website\docusaurus.config.ts`の下記scriptsを追加することにより、plausibleにアクセス数が集計される仕組みになっている。
+
+```js
+  ・
+  ・
+  ・
+  plugins,
+  scripts: [
+    {
+      src: 'https://plausible.io/js/pa-HCRkSORSKyT_D_l9FX2DM.js',
+      async: true,
+    },
+    {
+      src: `${urlWithBase}js/plausible.js`,
+      defer: true,
+    }
+  ],
+  presets: [
+    [
+  ・
+  ・
+  ・
+```
+
+なお、テストなどでローカルで起動したサーバーにアクセスした際は、集計対象にならない。

--- a/website/docs/claude-code-guide/02_basics/04_first-app.md
+++ b/website/docs/claude-code-guide/02_basics/04_first-app.md
@@ -183,13 +183,13 @@ Mavenによるビルドの確認と、場合によってはマイグレーショ
 
 ## 3. マッパーの作成
 
-### UserMapperの作成
+### TaskMapperの作成
 
-次にMyBatisのUserMapperを作成してみましょう。  
+次にMyBatisのTaskMapperを作成してみましょう。  
 Plan Modeにしてから以下のプロンプトを入力してください。
 
 ```txt
-MyBatisのUserMapperを作成してください。
+MyBatisのTaskMapperを作成してください。
 SQLは全てxml側に記述してください。
 
 基本的なCRUDに加えて、以下のカスタムメソッドも追加：

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -56,6 +56,16 @@ const config: Config = {
     locales: ['ja'],
   },
   plugins,
+  scripts: [
+    {
+      src: 'https://plausible.io/js/pa-HCRkSORSKyT_D_l9FX2DM.js',
+      async: true,
+    },
+    {
+      src: `${urlWithBase}js/plausible.js`,
+      defer: true,
+    }
+  ],
   presets: [
     [
       'classic',

--- a/website/static/js/plausible.js
+++ b/website/static/js/plausible.js
@@ -1,0 +1,2 @@
+window.plausible = window.plausible || function () { (plausible.q = plausible.q || []).push(arguments) }, plausible.init = plausible.init || function (i) { plausible.o = i || {} };
+plausible.init();


### PR DESCRIPTION
# plausibleでアクセス数を収集する設定を追加

plausibleでアクセス数を収集するためにScriptを追加しました。このScriptはplausible公式でガイディングされているものです。

### 確認内容

* ビルドした際に、追加したScriptがHTMLに反映されていることを確認
* 本番用ビルドした際に、base URLが適切に反映され、参照可能なパスになっていることを確認
* ローカルでWebサーバが起動して閲覧できることを確認（ただし、ローカル起動ではplausibleとの疎通確認は検証不可）
* 別のDocusaurusプロジェクトと、GitHubのPages機能で同様の設定を入れることでアクセス数が集計できることを確認

### リスク

* plausibleとの疎通確認は本PRをマージした後しか実施できません
* 疎通が失敗したとしても、ユーザーがガイドを参照できなくなるという事態にはなりません

### plausibleのアクセス収集の仕組み

二つのJavascriptファイルを利用しています。

* 初期化スニペット（plausible.js）は、イベントキュー・設定情報を一時保存するためのもの
   * 本体が未ロードでもイベントロストしない
* 本体スクリプト（pa-xxxx.js）は、実際にイベントを監視・送信するもの
  * ページビューやクリック、フォーム送信・ファイルDLなどを自動検知
  * イベントを収集し、PlausibleのサーバーにPOSTリクエストを送信する
  * ローカル環境ではイベントを送信しない

■ 簡易フロー
[ユーザー操作]
     ↓
[初期化スニペット plausible.js]
     ↓ (イベントを plausible.q に push)
[本体スクリプト pa-xxxx.js ロード後]
     ↓ (キューを処理)
[イベント監視・送信]
     ↓
[Plausible サーバー]



# ISSUE #19対応
#19 の対応をしました。
念のためClaude Codeにプロンプトを渡し、TaskMapperクラスが生成されていることを確認してます。

### 横並びチェックとして以下を実施
* 同ファイル内で同じようにプロンプトと生成結果に矛盾している部分がないか目視で確認
* ClaudeCodeガイドの全体に対して、プロンプトと生成結果に矛盾している部分がないかAIで確認